### PR TITLE
Remove player_twi account from target accounts

### DIFF
--- a/script.rb
+++ b/script.rb
@@ -8,6 +8,9 @@ spreadsheet_url = ENV['SPREADSHEET_URL']
 
 DatabaseClient.all.each do |twitter_account|
   next if twitter_account['name'] == 'Playerapp_cbsk'
+  # I remove Player_twi because this account has too much data.
+  # But I want to save cookies data, so deal with it by adding next process.
+  next if twitter_account['name'] == 'Player_twi'
   analytics_client = TwitterAnalyticsClient.new(twitter_account)
   csv = analytics_client.get_analytics_data_with_cookies
   csv ||= analytics_client.get_analytics_data_with_login


### PR DESCRIPTION
# Description
This PR is to remove @player_twi from target accounts.
Because this account has too much data and cause memory errors. https://github.com/ookamiinc/twitter-analytics-acquirer/issues/28

So I add next process.

## Note 
If you are eager to get Player_twi account, I recommend that you add one more server.